### PR TITLE
Making event tab for 2025 APA

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -3,8 +3,8 @@ title: AAPiG
 menu: main
 weight: -100
 banner:
-  enabled: false
-  message: "Explore Our Upcoming Events!"
+  enabled: true
+  message: "Explore Our Upcoming 2025 APA Heritage Month Events!"
   link: "https://aapigeosci.org/events/currentevents/"
 indexText: >-
   # Asian Americans and Pacific Islanders in Geosciences

--- a/content/events/currentevents/index.md
+++ b/content/events/currentevents/index.md
@@ -1,12 +1,15 @@
 ---
-title: Upcoming Events
+title: Upcoming 2025 APA Heritage Month Events
 menu: 
   main:
     parent: Events
 weight: 50
 ---
 
-There are no upcoming events at this time. Explore our [event archive](https://aapigeosci.org/events/oldevents/).
+# AAPIIG-wide Virtual Mixer on May 02, 2025.
+
+<!--- There are no upcoming events at this time. Explore our [event archive](https://aapigeosci.org/events/oldevents/).
+-->
 
 <!---
 # LGBTQIA+ Virtual Mixer

--- a/content/events/mixers/index.md
+++ b/content/events/mixers/index.md
@@ -4,6 +4,7 @@ menu:
   main:
     parent: Events
 weight: 50
+draft: true
 ---
 
 There are no upcoming mixers at this time. Explore our [event archive](https://aapigeosci.org/events/oldevents/).


### PR DESCRIPTION
Added banner (draft = false) to homepage linking to APA tab. Changed current events tab to "2025 APA Heritage Month Events". Will add flyers later once available.