### PR TITLE
Updating AGILE page

### DIFF
--- a/content/resources/AGILE/index.md
+++ b/content/resources/AGILE/index.md
@@ -9,4 +9,7 @@ draft: false
 
 <a href="https://sites.brown.edu/aapi-earth/" target="_blank"> ![AGILE logo.](AAPIiG-AGILE-NSF-logo_circletext800_CJuang_v2.png)</a>
 
-<a href="https://sites.brown.edu/aapi-earth/" target="_blank">AGILE</a> is a multi-institution project supported by an NSF GOLD-EN award that includes programs to enhance participation and belonging for Asian American and Pacific Islander (AAPI) communities in geosciences.
+AGILE was a multi-institution project supported by an NSF GOLD-EN award that included programs to enhance participation and belonging for Asian American and Pacific Islander (AAPI) communities in geosciences.
+
+<!--
+<a href="https://sites.brown.edu/aapi-earth/" target="_blank">AGILE</a> is a multi-institution project supported by an NSF GOLD-EN award that includes programs to enhance participation and belonging for Asian American and Pacific Islander (AAPI) communities in geosciences. --->


### PR DESCRIPTION
Removed hyperlink to official AGILE page. Changed wording to past tense.